### PR TITLE
feat: prioritize requested changes over new issues

### DIFF
--- a/src/server/orchestrator/github-poller.ts
+++ b/src/server/orchestrator/github-poller.ts
@@ -9,6 +9,7 @@ import { isRateLimited } from './rate-limit.js'
 import { isWorkerSlotFree, claimWorkerSlot, releaseWorkerSlot } from './worker-lock.js'
 import { logActivity } from './activity-log.js'
 import { isRepoAllowed } from './allowed-repos.js'
+import { hasPendingPrReviews } from './pr-poller.js'
 
 const MAX_ATTEMPTS = 3
 let lastPollTime: number | null = null
@@ -56,6 +57,13 @@ export function pollGitHub() {
   // Single task mode: skip if ANY worker is already running (global lock)
   if (!isWorkerSlotFree()) {
     console.log('[poller] Worker active (global lock), skipping poll')
+    return
+  }
+
+  // Yield to PR reviews — requested changes take priority over new issues
+  if (hasPendingPrReviews()) {
+    console.log('[poller] Pending PR reviews exist — yielding priority to pr-poller')
+    logActivity('poller', 'Yielding to PR reviews (requested changes have priority)')
     return
   }
 

--- a/src/server/orchestrator/pr-poller.ts
+++ b/src/server/orchestrator/pr-poller.ts
@@ -2,7 +2,7 @@ import { execFileSync } from 'child_process'
 import { existsSync } from 'fs'
 import { loadConfig } from './config.js'
 import { MAINTENANCE_FILE } from '../paths.js'
-import { getIssueState, setIssueState } from './state.js'
+import { getIssueState, setIssueState, getAllIssues } from './state.js'
 import { spawnPrWorker } from './pr-worker.js'
 import { makeLogPath } from './worker.js'
 import { notify } from './notifier.js'
@@ -19,6 +19,20 @@ let enabled = false
 
 export function getPrPollerState() {
   return { lastPollTime, pollStatus, enabled }
+}
+
+/**
+ * Check if there are any pending PR reviews (failed/retryable items with type 'pr').
+ * Used by the issue poller to yield priority to requested changes.
+ */
+export function hasPendingPrReviews(): boolean {
+  const issues = getAllIssues()
+  for (const [key, state] of Object.entries(issues)) {
+    if (!key.startsWith('pr:')) continue
+    if (state.status === 'failed' && (state.attempts || 0) < MAX_ATTEMPTS) return true
+    if (state.status === 'pending') return true
+  }
+  return false
 }
 
 export function stopPrPolling() {


### PR DESCRIPTION
## Summary
- Issue poller now yields to the PR poller when there are pending PR reviews (requested changes)
- New `hasPendingPrReviews()` exported from pr-poller checks state for retryable/pending `pr:` items
- When yielding, logs to activity feed so it's visible in the dashboard

**Before:** Both pollers raced for the worker slot — whichever ran first won, regardless of priority.
**After:** Requested changes always get picked up before new issues.

## Test plan
- [ ] With a pending PR review + open issue, verify the issue poller yields
- [ ] Activity log shows "Yielding to PR reviews" message
- [ ] Once PR reviews are cleared, issue poller picks up new issues normally
- [ ] No circular dependency between pollers

🤖 Generated with [Claude Code](https://claude.com/claude-code)