### PR TITLE
fix: use RELEASE_TOKEN and add packageManager for CI

### DIFF
--- a/.changeset/calm-tigers.md
+++ b/.changeset/calm-tigers.md
@@ -1,0 +1,5 @@
+---
+"ultradev-dashboard": patch
+---
+
+Fix release workflow: use RELEASE_TOKEN secret instead of GITHUB_TOKEN for elevated permissions, and add packageManager field to package.json to fix pnpm setup failure in CI.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           commit: "chore: version packages"
           version: pnpm changeset version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Create GitHub Release
         if: steps.changesets.outputs.hasChangesets == 'false' && steps.changesets.outputs.published == 'false'
@@ -65,4 +65,4 @@ jobs:
             --notes "${NOTES:-Release ${TAG}}" \
             --target main
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ultradev-dashboard",
   "version": "1.0.0",
   "private": true,
+  "packageManager": "pnpm@10.18.0",
   "type": "module",
   "scripts": {
     "dev": "tsx src/server/index.ts",


### PR DESCRIPTION
## Summary
- Replace `secrets.GITHUB_TOKEN` with `secrets.RELEASE_TOKEN` in release workflow for elevated permissions
- Add `"packageManager": "pnpm@10.18.0"` to `package.json` to fix `pnpm/action-setup@v4` failing with "No pnpm version is specified"

## Test plan
- [ ] Verify `RELEASE_TOKEN` secret is configured in GitHub repo settings
- [ ] Merge and confirm the release workflow passes (pnpm setup + changesets action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)