### PR TITLE
fix: review timestamp Date vs string comparison loop

### DIFF
--- a/src/server/orchestrator/github-sync.ts
+++ b/src/server/orchestrator/github-sync.ts
@@ -320,7 +320,10 @@ async function dispatch() {
 
       // If marked done, check for new review feedback (from DB, no API call)
       if (state?.status === 'done') {
+        // Normalize to ISO string for comparison (pg returns Date objects)
         const latestReviewAt = pr.latest_review_at
+          ? new Date(pr.latest_review_at as any).toISOString()
+          : null
         if (!latestReviewAt || (state.lastReviewAt && latestReviewAt <= state.lastReviewAt)) {
           continue
         }
@@ -516,6 +519,8 @@ export async function hasPendingWork(): Promise<boolean> {
     const state = getIssueState(key)
     if (state?.status === 'done') {
       const latestReviewAt = pr.latest_review_at
+        ? new Date(pr.latest_review_at as any).toISOString()
+        : null
       if (latestReviewAt && (!state.lastReviewAt || latestReviewAt > state.lastReviewAt)) return true
       continue
     }


### PR DESCRIPTION
## Summary
- `pg` returns `TIMESTAMPTZ` columns as JavaScript `Date` objects
- `state.json` stores `lastReviewAt` as ISO strings
- `Date <= string` always returns `false`, so dispatch kept re-queuing "done" PRs every cycle
- Fix: normalize to ISO string before comparing

Root cause of the #868/#869 infinite re-queue loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pull request review timestamp comparison logic. Review timestamps are now consistently normalized to ISO string format before evaluation, ensuring accurate status tracking and proper management of pull request work queues when review changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->