### PR TITLE
fix: use GitHub Releases consistently for updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,22 +47,23 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           TAG="v${VERSION}"
 
-          # Check if tag already exists
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists, skipping release"
+          # Check if release already exists (not just the tag)
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists, skipping"
             exit 0
           fi
 
-          # Create tag and release
-          git tag "$TAG"
-          git push origin "$TAG"
+          # Create tag if it doesn't exist yet
+          if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+            git tag "$TAG"
+            git push origin "$TAG"
+          fi
 
           # Extract latest changelog entry for release notes
           NOTES=$(sed -n '/^## /,/^## /{ /^## /!p; }' CHANGELOG.md 2>/dev/null | head -50 || echo "Release ${TAG}")
 
           gh release create "$TAG" \
             --title "$TAG" \
-            --notes "${NOTES:-Release ${TAG}}" \
-            --target main
+            --notes "${NOTES:-Release ${TAG}}"
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/src/server/routes/version.ts
+++ b/src/server/routes/version.ts
@@ -45,25 +45,18 @@ router.get('/', async (_req, res) => {
 
 router.post('/update', async (_req, res) => {
   try {
-    // Fetch latest tags
-    await execFileAsync('git', ['fetch', '--tags'], { timeout: 30_000, encoding: 'utf-8' })
-
-    // Get latest tag
-    const { stdout: revOut } = await execFileAsync('git', [
-      'rev-list', '--tags', '--max-count=1',
-    ], { timeout: 10_000, encoding: 'utf-8' })
-
-    const { stdout: tagOut } = await execFileAsync('git', [
-      'describe', '--tags', '--abbrev=0', revOut.trim(),
-    ], { timeout: 10_000, encoding: 'utf-8' })
-
-    const latestTag = tagOut.trim()
+    // Get latest release tag from GitHub Releases (same source as detection)
+    cachedLatest = null
+    const latestTag = await getLatestRelease()
     if (!latestTag) {
       res.status(404).json({ error: 'No release tags found' })
       return
     }
 
-    // Checkout latest tag
+    // Fetch tags so the release tag is available locally
+    await execFileAsync('git', ['fetch', '--tags'], { timeout: 30_000, encoding: 'utf-8' })
+
+    // Checkout latest release tag
     await execFileAsync('git', ['checkout', latestTag], { timeout: 10_000, encoding: 'utf-8' })
 
     // Install dependencies


### PR DESCRIPTION
## Summary
- **Release workflow**: Now checks if the *release* exists (not just the tag) before skipping. Creates the release even if the tag was previously pushed — fixes the current v1.1.0 situation where the tag exists but the release creation failed with a 403.
- **Update endpoint**: Uses `gh release view` (GitHub Releases) instead of `git rev-list --tags` (any git tag), matching the detection endpoint so both use the same source of truth.

## Context
The v1.1.0 tag was pushed successfully but `gh release create` failed with HTTP 403 due to insufficient token permissions. The old workflow then skipped on subsequent runs because the tag already existed. With this fix, the next CI run after merge will create the v1.1.0 release for the existing tag.

## Test plan
- [ ] Merge PR and verify CI creates the v1.1.0 GitHub Release
- [ ] Verify the v1.0.0 dashboard instance shows the update button
- [ ] Click update and verify it pulls the release tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)