### PR TITLE
fix: run database migrations during update process

### DIFF
--- a/.changeset/swift-eagles.md
+++ b/.changeset/swift-eagles.md
@@ -1,0 +1,5 @@
+---
+"ultradev-dashboard": patch
+---
+
+Fix update process to run database migrations and seed after installing dependencies. Fix Prisma 7 config to use `datasource.url` instead of `migrate.url`, and fix seed script to use the PrismaPg adapter pattern.

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from 'prisma/config'
 export default defineConfig({
   earlyAccess: true,
   schema: path.join('prisma', 'schema'),
-  migrate: {
+  datasource: {
     url: process.env.DATABASE_URL ?? 'postgresql://ultradev:ultradev@localhost:5432/ultradev',
   },
 })

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,7 +1,11 @@
 import { PrismaClient } from '@prisma/client'
+import { PrismaPg } from '@prisma/adapter-pg'
+import pg from 'pg'
 import { defaultSettings } from '../src/server/lib/defaults.js'
 
-const prisma = new PrismaClient()
+const pool = new pg.Pool({ connectionString: process.env.DATABASE_URL })
+const adapter = new PrismaPg(pool)
+const prisma = new PrismaClient({ adapter })
 
 const settings = defaultSettings
 
@@ -214,9 +218,13 @@ async function main() {
 }
 
 main()
-  .then(async () => await prisma.$disconnect())
+  .then(async () => {
+    await prisma.$disconnect()
+    await pool.end()
+  })
   .catch(async (e) => {
     console.error(e)
     await prisma.$disconnect()
+    await pool.end()
     process.exit(1)
   })

--- a/src/client/pages/UpdatePage.tsx
+++ b/src/client/pages/UpdatePage.tsx
@@ -5,6 +5,7 @@ import {
   Download,
   GitBranch,
   Package,
+  Database,
   RotateCcw,
   Check,
   AlertCircle,
@@ -16,7 +17,7 @@ import { api } from '@/lib/api'
 
 // --- Types ---
 
-type StepName = 'fetch' | 'checkout' | 'install' | 'restart'
+type StepName = 'fetch' | 'checkout' | 'install' | 'migrate' | 'restart'
 type StepStatus = 'pending' | 'in_progress' | 'done' | 'error'
 
 interface UpdateStep {
@@ -38,10 +39,11 @@ const STEP_META: Record<StepName, { label: string; icon: typeof Download }> = {
   fetch: { label: 'Fetch', icon: Download },
   checkout: { label: 'Checkout', icon: GitBranch },
   install: { label: 'Install', icon: Package },
+  migrate: { label: 'Migrate', icon: Database },
   restart: { label: 'Restart', icon: RotateCcw },
 }
 
-const STEP_ORDER: StepName[] = ['fetch', 'checkout', 'install', 'restart']
+const STEP_ORDER: StepName[] = ['fetch', 'checkout', 'install', 'migrate', 'restart']
 
 // --- Helpers ---
 

--- a/src/server/routes/version.ts
+++ b/src/server/routes/version.ts
@@ -15,7 +15,7 @@ const CACHE_TTL = 10 * 60 * 1000 // 10 minutes
 // ---------------------------------------------------------------------------
 
 interface UpdateStep {
-  step: 'fetch' | 'checkout' | 'install' | 'restart'
+  step: 'fetch' | 'checkout' | 'install' | 'migrate' | 'restart'
   status: 'pending' | 'in_progress' | 'done' | 'error'
   message: string
 }
@@ -34,6 +34,7 @@ function makeSteps(): UpdateStep[] {
     { step: 'fetch', status: 'pending', message: 'Fetch tags' },
     { step: 'checkout', status: 'pending', message: 'Checkout release' },
     { step: 'install', status: 'pending', message: 'Install dependencies' },
+    { step: 'migrate', status: 'pending', message: 'Run database migrations' },
     { step: 'restart', status: 'pending', message: 'Restart server' },
   ]
 }
@@ -100,7 +101,22 @@ async function runUpdate(latestTag: string) {
     })
     setStepStatus('install', 'done', 'Dependencies installed')
 
-    // Step 4 — restart
+    // Step 4 — database migrations + seed
+    setStepStatus('migrate', 'in_progress', 'Pushing schema changes…')
+    await execFileAsync('pnpm', ['exec', 'prisma', 'db', 'push', '--skip-generate'], {
+      timeout: 60_000,
+      encoding: 'utf-8',
+      env: { ...process.env },
+    })
+    setStepStatus('migrate', 'in_progress', 'Seeding database…')
+    await execFileAsync('pnpm', ['exec', 'prisma', 'db', 'seed'], {
+      timeout: 60_000,
+      encoding: 'utf-8',
+      env: { ...process.env },
+    })
+    setStepStatus('migrate', 'done', 'Database updated')
+
+    // Step 5 — restart
     setStepStatus('restart', 'in_progress', 'Restarting server…')
     setStepStatus('restart', 'done', 'Restart initiated')
     // Reset active flag so a stale state doesn't block future updates


### PR DESCRIPTION
## Summary
- Add `prisma db push` and `prisma db seed` steps to the update flow in `version.ts`, between dependency install and server restart
- Fix `prisma.config.ts` to use `datasource.url` instead of `migrate.url` (required by Prisma 7)
- Fix `prisma/seed.ts` to use `PrismaPg` adapter pattern instead of bare `new PrismaClient()` (which crashes in Prisma 7)
- Add "Migrate" step to the frontend update progress UI with a Database icon

Closes #29

## Test plan
- [ ] Verify `prisma db push` works with the updated `prisma.config.ts`
- [ ] Verify `prisma db seed` works with the adapter-pattern `seed.ts`
- [ ] Trigger an update via the UI and confirm the new "Migrate" step appears in the progress tracker
- [ ] Confirm the update flow completes successfully end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the update process to automatically run database migrations and seeding after dependency installation.
  * Added a visible migration step to the update progress display to track database schema changes and data seeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->