### PR TITLE
feat: upgrade workflow — one-at-a-time, CodeRabbit loop, nitpick triage, changesets

### DIFF
--- a/.changeset/workflow-upgrade.md
+++ b/.changeset/workflow-upgrade.md
@@ -1,0 +1,5 @@
+---
+"ultradev-dashboard": minor
+---
+
+Upgrade autonomous workflow: enforce one-issue-at-a-time, CodeRabbit review loop closure, nitpick triage, and mandatory changesets

--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -38,5 +38,17 @@ Create a pull request for the current branch with a changeset.
   🤖 Generated with [Claude Code](https://claude.com/claude-code)
   ```
 
-### 4. Output
+### 4. CodeRabbit Review Loop
+- Wait for CI: `gh pr checks <number> --watch`
+- If CI fails, fix the issue, commit, push, and repeat
+- Comment `@coderabbitai review` on the PR to trigger review
+- Poll `gh pr view <number> --json reviewDecision --jq .reviewDecision` every 60s
+- If CHANGES_REQUESTED:
+  - Read all comments
+  - For nitpicks (🧹/🔵): reply with reasoning, resolve thread
+  - For real issues: fix code, push, resolve ALL threads, comment `@coderabbitai review`
+  - Repeat polling
+- If APPROVED + CI green: `gh pr merge <number> --squash --delete-branch --auto`
+
+### 5. Output
 - Print the PR URL when done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ After every push that addresses review feedback:
 ### Changesets (REQUIRED)
 
 - Always include a changeset file when making changes.
-- Create `.changeset/<branch-name>.md` with the package name and semver bump.
+- Create `.changeset/<adjective>-<noun>.md` (e.g., `brave-pandas.md`) with the package name and semver bump, matching the `@changesets/cli` naming convention.
 - Use `patch` for bug fixes, `minor` for features, `major` for breaking changes.
 - Skip only if the repo has no `.changeset/config.json`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# UltraDev
+
+Autonomous AI developer orchestrator. Polls GitHub for assigned issues, spawns Claude Code workers, creates PRs, handles review feedback, and merges.
+
+## Stack
+
+- TypeScript, Node 22, pnpm
+- Vite + React 19 frontend, Express 5 backend
+- PostgreSQL via Prisma ORM
+- systemd user services
+
+## Workflow Rules (MANDATORY)
+
+### One Issue At A Time
+
+- NEVER start a new issue while any open PR exists (review pending, CI running, conflicts, or auto-mergeable).
+- The full lifecycle: branch -> code -> changeset -> push -> PR -> CI green -> CodeRabbit review -> address feedback -> resolve threads -> re-review -> approved -> merge -> verify issue closed -> THEN pick next issue.
+- The dispatch system enforces this: issues are blocked when open PRs exist.
+
+### CodeRabbit Review Loop (NEVER skip)
+
+After every push that addresses review feedback:
+
+1. **Resolve ALL review threads** you addressed (both code fixes and nitpick replies)
+2. **Comment `@coderabbitai review`** to trigger re-review
+3. **Poll for review decision** (`gh pr view <number> --json reviewDecision`) every 60s until APPROVED or new CHANGES_REQUESTED
+
+### Nitpicks vs Real Issues
+
+- CodeRabbit marks everything CHANGES_REQUESTED, even for trivial nitpicks.
+- Comments labeled with `Nitpick` or `Trivial`: reply with brief reasoning, resolve the thread. No code change needed.
+- Real issues: fix code, push, resolve thread, request re-review.
+- You MUST respond to and resolve ALL threads regardless — CodeRabbit won't approve until threads are resolved.
+
+### Changesets (REQUIRED)
+
+- Always include a changeset file when making changes.
+- Create `.changeset/<branch-name>.md` with the package name and semver bump.
+- Use `patch` for bug fixes, `minor` for features, `major` for breaking changes.
+- Skip only if the repo has no `.changeset/config.json`.
+
+### PR Merge Flow
+
+- When APPROVED + CI green: `gh pr merge --squash --delete-branch --auto`
+- After merge, verify the linked issue auto-closed. If not: `gh issue close <number>`
+
+## Development
+
+```bash
+pnpm install          # install deps
+pnpm dev              # dev server (Vite + Express)
+pnpm build            # production build
+pnpm typecheck        # tsc --noEmit
+```
+
+## Testing
+
+```bash
+pnpm test             # run tests if they exist
+pnpm typecheck        # type checking
+```
+
+## Code Style
+
+- No semicolons (configured in project)
+- Single quotes
+- 2-space indent
+- ES modules (type: "module")
+- Prisma for DB access, never raw SQL

--- a/src/server/orchestrator/github-poller.ts
+++ b/src/server/orchestrator/github-poller.ts
@@ -72,7 +72,8 @@ async function buildPrompt(repo: string, number: number, detail: any, existingPr
 
   const changesetStep = `5. **Create a changeset** (REQUIRED):
    - Check if \`.changeset/config.json\` exists. If it does, this repo uses changesets.
-   - Create a changeset file: \`.changeset/<adjective>-<noun>.md\` (e.g., \`brave-pandas.md\`) with format:
+   - Check if a changeset file already exists in \`.changeset/\` (any \`.md\` file other than \`README.md\`). If one already exists, skip creating a new one.
+   - If no changeset exists, create one: \`.changeset/<adjective>-<noun>.md\` (e.g., \`brave-pandas.md\`) with format:
      \`\`\`
      ---
      "<package-name>": patch

--- a/src/server/orchestrator/github-poller.ts
+++ b/src/server/orchestrator/github-poller.ts
@@ -72,7 +72,7 @@ async function buildPrompt(repo: string, number: number, detail: any, existingPr
 
   const changesetStep = `5. **Create a changeset** (REQUIRED):
    - Check if \`.changeset/config.json\` exists. If it does, this repo uses changesets.
-   - Create a changeset file: \`.changeset/<branch-name>.md\` with format:
+   - Create a changeset file: \`.changeset/<adjective>-<noun>.md\` (e.g., \`brave-pandas.md\`) with format:
      \`\`\`
      ---
      "<package-name>": patch

--- a/src/server/orchestrator/github-poller.ts
+++ b/src/server/orchestrator/github-poller.ts
@@ -70,19 +70,57 @@ async function buildPrompt(repo: string, number: number, detail: any, existingPr
     .map((c: any) => `**${c.author.login}**: ${c.body}`)
     .join('\n\n')
 
-  const ciWaitStep = `8. After pushing, wait for CI checks to complete. Run this in a loop every 30 seconds until all checks finish:
-   \`gh pr checks <PR_NUMBER> --repo ${repo} --watch\`
-   If any check fails, read the failure logs, fix the issue, commit, and push again. Repeat until CI is green.`
+  const changesetStep = `5. **Create a changeset** (REQUIRED):
+   - Check if \`.changeset/config.json\` exists. If it does, this repo uses changesets.
+   - Create a changeset file: \`.changeset/<branch-name>.md\` with format:
+     \`\`\`
+     ---
+     "<package-name>": patch
+     ---
+
+     <Summary of what changed and why>
+     \`\`\`
+   - Use \`patch\` for bug fixes, \`minor\` for new features, \`major\` for breaking changes.
+   - Find the package name from the root \`package.json\` \`name\` field.
+   - If the repo doesn't use changesets (no \`.changeset/config.json\`), skip this step.`
+
+  const coderabbitLoop = `
+## CRITICAL: Close the CodeRabbit review loop
+
+After creating/updating the PR, you MUST:
+
+A. **Wait for CI:** \`gh pr checks <PR_NUMBER> --repo ${repo} --watch\`
+   If any check fails, fix the issue, commit, push, and repeat.
+
+B. **Request CodeRabbit review:**
+   \`gh pr comment <PR_NUMBER> --repo ${repo} --body "@coderabbitai review"\`
+
+C. **Poll for review decision (up to 10 minutes):**
+   Run every 60 seconds:
+   \`gh pr view <PR_NUMBER> --repo ${repo} --json reviewDecision --jq .reviewDecision\`
+   - If APPROVED + CI green: \`gh pr merge <PR_NUMBER> --repo ${repo} --squash --delete-branch --auto\`
+   - If CHANGES_REQUESTED: read feedback, triage (nitpicks vs real issues), fix, push, resolve threads, request re-review, repeat.
+   - If REVIEW_REQUIRED after 10 min: stop, orchestrator will handle next cycle.
+
+D. **Handling CodeRabbit feedback:**
+   - 🧹 Nitpick / 🔵 Trivial: reply with brief reasoning, resolve thread, no code change needed.
+   - Real issues: fix code, push, resolve ALL threads, then \`@coderabbitai review\`.
+
+E. **Verify issue closure:**
+   After merge, check: \`gh issue view ${number} --repo ${repo} --json state --jq .state\`
+   If still open: \`gh issue close ${number} --repo ${repo}\``
 
   const prInstructions = existingPrUrl
-    ? `5. Commit your changes with a clear message referencing #${number}.
-6. Push your commits to this branch: \`git push origin HEAD\`
-7. The existing PR (${existingPrUrl}) will be updated automatically. Do NOT create a new PR.
-${ciWaitStep}`
-    : `5. Commit your changes with a clear message referencing #${number}.
-6. Push this branch and create a pull request using \`gh pr create\`.
-7. The PR title should reference the issue. The PR body should explain what you changed and why.
-${ciWaitStep}`
+    ? `${changesetStep}
+6. Commit your changes with a clear message referencing #${number}.
+7. Push your commits to this branch: \`git push origin HEAD\`
+8. The existing PR (${existingPrUrl}) will be updated automatically. Do NOT create a new PR.
+${coderabbitLoop}`
+    : `${changesetStep}
+6. Commit your changes with a clear message referencing #${number}.
+7. Push this branch and create a pull request using \`gh pr create\`.
+8. The PR title should reference the issue. The PR body should explain what you changed and why.
+${coderabbitLoop}`
 
   const resumeContext = existingPrUrl
     ? `## IMPORTANT: Resuming Previous Work

--- a/src/server/orchestrator/intelligent-dispatch.ts
+++ b/src/server/orchestrator/intelligent-dispatch.ts
@@ -170,9 +170,24 @@ export async function intelligentDispatch(plate: Plate, config: Config): Promise
     return { action: 'skip', repo: '', number: 0, reasoning: 'All items are done, in_progress, or have no actionable signal.' }
   }
 
+  // --- ONE-AT-A-TIME RULE ---
+  // If there are any open PRs that are NOT yet merged (pr_review, conflict, auto_merge, pr_open),
+  // do NOT start new issues. Focus on getting existing PRs through the review→merge lifecycle.
+  const hasOpenPrs = plate.items.some(i =>
+    (i.type === 'pr_review' || i.type === 'conflict' || i.type === 'auto_merge' || i.type === 'pr_open') &&
+    i.status !== 'done'
+  )
+  const filteredItems = hasOpenPrs
+    ? actionableItems.filter(i => i.type !== 'issue')
+    : actionableItems
+
+  if (filteredItems.length === 0) {
+    return { action: 'skip', repo: '', number: 0, reasoning: 'Open PRs exist — finish PR lifecycle before starting new issues.' }
+  }
+
   // If only one actionable item, no need to call Claude
-  if (actionableItems.length === 1) {
-    const item = actionableItems[0]
+  if (filteredItems.length === 1) {
+    const item = filteredItems[0]
     const actionMap: Record<PlateItem['type'], DispatchDecision['action']> = {
       'issue': 'handle_issue',
       'pr_review': 'handle_pr_review',
@@ -184,11 +199,11 @@ export async function intelligentDispatch(plate: Plate, config: Config): Promise
       action: actionMap[item.type],
       repo: item.repo,
       number: item.number,
-      reasoning: 'Only one actionable item.',
+      reasoning: hasOpenPrs ? 'Only one actionable PR item (issues blocked by open PRs).' : 'Only one actionable item.',
     }
   }
 
-  const actionablePlate: Plate = { ...plate, items: actionableItems }
+  const actionablePlate: Plate = { ...plate, items: filteredItems }
   const prompt = buildDispatchPrompt(actionablePlate)
 
   try {
@@ -219,6 +234,12 @@ function buildDispatchPrompt(plate: Plate): string {
 
 ${itemList}
 
+## CRITICAL RULE: One issue at a time
+- NEVER start a new issue if any open PR exists (review pending, conflicts, CI failing, or auto-mergeable).
+- The full lifecycle is: issue → branch → code → push → PR → CI green → CodeRabbit review → address feedback → merge → THEN next issue.
+- If there are open PRs on the plate, ONLY pick PR-related actions (handle_pr_review, handle_conflict, auto_merge).
+- Only pick handle_issue when there are ZERO open PRs.
+
 ## Decision guidelines:
 - status='done' with no new activity since last addressed → SKIP (already handled)
 - status='done' but "Latest review" timestamp > "Last addressed" timestamp → NEW FEEDBACK arrived, should iterate on the PR
@@ -228,8 +249,7 @@ ${itemList}
 - Merge conflicts block progress on existing work — resolve them
 - Auto-mergeable PRs (type=auto_merge) are quick wins — merge them to clear the queue
 - Items with many failed attempts (3+) should be deprioritized — they may need human intervention
-- Consider the big picture: many open PRs → focus on getting them merged rather than creating more
-- New issues (status='pending', attempts=0) are fair game
+- New issues (status='pending', attempts=0) are ONLY fair game if there are no open PRs
 
 ## Response format
 
@@ -273,8 +293,15 @@ function parseDecision(text: string, plate: Plate): DispatchDecision {
 }
 
 // Fallback: use the old priority order if Claude fails
+// Respects one-at-a-time: auto_merge > pr_review > conflict first, then issues only if no PRs
 function fallbackDispatch(plate: Plate): DispatchDecision {
-  const priorityOrder: PlateItem['type'][] = ['pr_review', 'conflict', 'issue', 'auto_merge']
+  const hasOpenPrs = plate.items.some(i =>
+    (i.type === 'pr_review' || i.type === 'conflict' || i.type === 'auto_merge' || i.type === 'pr_open') &&
+    i.status !== 'done'
+  )
+  const priorityOrder: PlateItem['type'][] = hasOpenPrs
+    ? ['auto_merge', 'pr_review', 'conflict']
+    : ['auto_merge', 'pr_review', 'conflict', 'issue']
 
   for (const type of priorityOrder) {
     const item = plate.items.find(i => i.type === type)

--- a/src/server/orchestrator/pr-worker.ts
+++ b/src/server/orchestrator/pr-worker.ts
@@ -215,20 +215,58 @@ The PR merges \`${prBranch}\` into \`${pr.baseRefName}\`.
 ## Instructions
 
 1. Read and understand ALL the review feedback carefully.
-2. Explore the relevant code to understand context.
-3. Make the requested changes on this branch (\`${prBranch}\`).
-4. Run tests if they exist. Use \`pnpm --filter <package> test\` to run tests.
-5. Commit your changes with a clear message describing what review feedback you addressed.
-6. Push your commits to origin: \`git push origin ${prBranch}\`
-7. The existing PR will be updated automatically. Do NOT create a new PR.
-8. After pushing, wait for CI checks to complete: \`gh pr checks ${pr.number} --repo ${repo} --watch\`
-   If any check fails, read the failure logs, fix the issue, commit, and push again. Repeat until CI is green.
+2. **Triage each comment:**
+   - If a comment is labeled 🧹 Nitpick or 🔵 Trivial: you do NOT need to change code. Instead, reply to the comment with a brief explanation of your reasoning, then resolve the thread.
+   - If a comment is a real issue (not a nitpick): fix the code as requested.
+3. Explore the relevant code to understand context.
+4. Make the requested changes on this branch (\`${prBranch}\`).
+5. Run tests if they exist. Use \`pnpm --filter <package> test\` to run tests.
+6. Commit your changes with a clear message describing what review feedback you addressed.
+7. Push your commits to origin: \`git push origin ${prBranch}\`
+8. The existing PR will be updated automatically. Do NOT create a new PR.
+
+## CRITICAL: Close the CodeRabbit review loop
+
+After pushing your changes, you MUST complete ALL of these steps:
+
+9. **Resolve ALL review threads** you addressed:
+   For each review comment (both fixed and nitpick-replied):
+   \`\`\`
+   gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thread_id>"}) { thread { isResolved } } }'
+   \`\`\`
+   To find thread IDs, use:
+   \`\`\`
+   gh api repos/${repo}/pulls/${pr.number}/comments --jq '.[] | {id: .node_id, body: .body[:80], path: .path}'
+   \`\`\`
+
+10. **Request CodeRabbit re-review:**
+    \`\`\`
+    gh pr comment ${pr.number} --repo ${repo} --body "@coderabbitai review"
+    \`\`\`
+
+11. **Wait for CI to pass:**
+    \`\`\`
+    gh pr checks ${pr.number} --repo ${repo} --watch
+    \`\`\`
+    If any check fails, read the failure logs, fix the issue, commit, push, and repeat from step 9.
+
+12. **Poll for review approval (up to 10 minutes):**
+    Run this in a loop every 60 seconds:
+    \`\`\`
+    gh pr view ${pr.number} --repo ${repo} --json reviewDecision --jq .reviewDecision
+    \`\`\`
+    - If APPROVED: you're done, the orchestrator will auto-merge.
+    - If CHANGES_REQUESTED: read new feedback and go back to step 1.
+    - If still REVIEW_REQUIRED after 10 min: stop polling, the orchestrator will pick it up on next cycle.
 
 ## CRITICAL RULES
 - Do NOT create a new branch. Stay on \`${prBranch}\`.
 - Do NOT create a new pull request. Just push to the existing branch.
 - **NEVER run \`pnpm install\`, \`pnpm add\`, \`npm install\`, or any dependency installation command.** Dependencies are already installed.
-- Do not ask questions — make reasonable decisions and proceed.`
+- Do not ask questions — make reasonable decisions and proceed.
+- ALWAYS resolve review threads and request re-review after pushing. Never skip this step.
+- For nitpicks (🧹/🔵): reply with reasoning, resolve thread, no code change needed.
+- For real issues: fix code, push, resolve thread, request re-review.`
 
   return prompt
 }


### PR DESCRIPTION
## Summary

- **One-at-a-time enforcement**: Dispatch now blocks new issues when any open PR exists. Full PR lifecycle (branch → code → PR → review → merge) must complete before picking the next issue. Both intelligent dispatch prompt and fallback logic enforce this.
- **CodeRabbit review loop closure**: PR worker and issue worker prompts now include explicit steps to resolve review threads, comment `@coderabbitai review`, and poll for approval every 60s.
- **Nitpick triage**: Workers now distinguish nitpick/trivial comments from real issues — reply with reasoning and resolve thread without code changes for nitpicks.
- **Mandatory changesets**: Issue worker prompt now includes a changeset creation step. `create-pr` command updated with review loop.
- **CLAUDE.md**: New repo-root file documenting permanent workflow rules.

## Test plan

- [ ] Deploy and verify dispatch skips new issues when open PRs exist
- [ ] Verify PR worker resolves threads and requests re-review after pushing fixes
- [ ] Verify issue worker creates changeset files
- [ ] Verify nitpick comments get reply-and-resolve treatment
- [ ] Type check passes (`pnpm typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced one-at-a-time workflow for sequential issue and PR handling.
  * Automated review loop with CI polling, iterative feedback handling, and approval tracking.
  * Mandatory changeset creation integrated into update/PR flow.
  * Triage rules to distinguish nitpicks from substantive issues and require thread resolution.

* **Documentation**
  * Added comprehensive workflow guide covering rules, review loop, development commands, and coding conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->